### PR TITLE
changed flagger patchesStrategicMerge patch.yaml to flagger-patch.yaml

### DIFF
--- a/cluster/flagger/kustomization.yaml
+++ b/cluster/flagger/kustomization.yaml
@@ -5,4 +5,4 @@ bases:
   - github.com/weaveworks/flagger/kustomize/base/flagger
   - github.com/weaveworks/flagger/kustomize/base/prometheus
 patchesStrategicMerge:
-  - patch.yaml
+  - flagger-patch.yaml


### PR DESCRIPTION
Just a small change. I kept getting the following error when I applied the Flagger base to a team. 

```
component=sync-loop err="loading resources from repo: error executing generator command \"kustomize build .\" from file \".flux.yaml\": exit status 1\nerror output:\nError: AccumulateTarget: SliceFromPatches: evalsymlink failure on '/tmp/flux-working749875113/cluster/flagger/patch.yaml' : lstat /tmp/flux-working749875113/cluster/flagger/patch.yaml: no such file or directory\n\n\n\ngenerated output:\nError: AccumulateTarget: SliceFromPatches: evalsymlink failure on '/tmp/flux-working749875113/cluster/flagger/patch.yaml' : lstat /tmp/flux-working749875113/cluster/flagger/patch.yaml: no such file or directory\n\n\n"
```

I was able to fix this by changing `flagger/kustomization/patch.yaml` to `flagger/kustomization/flagger-patch.yaml`. 

Thanks for putting together this repo, it's fantastic.