### PR TITLE
Add GitHub action workflow for manifests validation

### DIFF
--- a/.github/policy/deny.rego
+++ b/.github/policy/deny.rego
@@ -1,0 +1,9 @@
+package main
+
+import data.kubernetes
+
+deny[msg] {
+	kubernetes.containers[container]
+	[image_name, "latest"] = kubernetes.split_image(container.image)
+	msg = sprintf("%s in the %s %s has an image, %s, using the latest tag", [container.name, kubernetes.kind, image_name, kubernetes.name])
+}

--- a/.github/policy/kubernetes.rego
+++ b/.github/policy/kubernetes.rego
@@ -1,0 +1,53 @@
+package kubernetes
+
+# Variables
+
+name = input.metadata.name
+
+kind = input.kind
+
+is_service {
+	input.kind = "Service"
+}
+
+is_deployment {
+	input.kind = "Deployment"
+}
+
+is_pod {
+	input.kind = "Pod"
+}
+
+split_image(image) = [image, "latest"] {
+	not contains(image, ":")
+}
+
+split_image(image) = [name, tag] {
+	[name, tag] = split(image, ":")
+}
+
+pod_containers(pod) = all_containers {
+	keys = {"containers", "initContainers"}
+	all_containers = [c | keys[k]; c = pod.spec[k][_]]
+}
+
+containers[container] {
+	pods[pod]
+	all_containers = pod_containers(pod)
+	container = all_containers[_]
+}
+
+containers[container] {
+	all_containers = pod_containers(input)
+	container = all_containers[_]
+}
+
+pods[pod] {
+	is_deployment
+	pod = input.spec.template
+}
+
+pods[pod] {
+	is_pod
+	pod = input
+}

--- a/.github/policy/warn.rego
+++ b/.github/policy/warn.rego
@@ -1,0 +1,15 @@
+package main
+
+import data.kubernetes
+
+name = input.metadata.name
+
+annotations {
+  input.spec.selector.template.metadata.annotations["prometheus.io/scrape"]
+}
+
+warn[msg] {
+  kubernetes.is_deployment
+  not annotations
+  msg = sprintf("Deployment %s should set prometheus.io/scrape pod annotation", [name])
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate kustomization
+        uses: stefanprodan/kube-tools@1.0.0
+        with:
+          # https://github.com/fluxcd/flux/blob/master/docker/kubectl.version
+          kubectl: 1.14.7
+          # https://github.com/fluxcd/flux/blob/master/docker/kustomize.version
+          kustomize: 3.2.3
+          # https://github.com/fluxcd/helm-operator/blob/master/docker/helm.version
+          helm: 2.14.3
+          command: |
+            echo "Validating install"
+            kustomize build install | kubeval --strict --ignore-missing-schemas
+            echo "Validating cluster"
+            kustomize build cluster | kubeval --strict --ignore-missing-schemas
+            echo "Validating cluster/flagger"
+            kustomize build cluster/flagger | kubeval --strict --ignore-missing-schemas
+            echo "Validating cluster/gatekeeper"
+            kustomize build cluster/gatekeeper | kubeval --strict --ignore-missing-schemas

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,5 @@
-name: test
-
 on: [push, pull_request]
-
+name: test
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -25,3 +23,8 @@ jobs:
             kustomize build cluster/flagger | kubeval --strict --ignore-missing-schemas
             echo "Validating cluster/gatekeeper"
             kustomize build cluster/gatekeeper | kubeval --strict --ignore-missing-schemas
+      - name: Deny latest container image tags
+        uses: stefanprodan/kube-tools@1.0.0
+        with:
+          command: |
+            kustomize build cluster | conftest test -p .github/policy -

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fluxcd-multi-tenancy
 
+[![test](https://github.com/fluxcd/multi-tenancy/workflows/test/badge.svg)](https://github.com/fluxcd/multi-tenancy/.github/workflows/test.yaml)
+
 This repository serves as a starting point for a multi-tenant cluster managed with Git, Flux and Kustomize.
 
 I'm assuming that a multi-tenant cluster is shared by multiple teams. The cluster wide operations are performed by 


### PR DESCRIPTION
This PR adds two validation jobs:
* validates the kustomize build with kubeval
* validates that the `latest` container image tag is not present in any manifests with conftest
* warns if the `prometheus.io/scrape` annotation is not present on pods