### PR TITLE
fix(rules.rego): remove "selector." from "selector.template"

### DIFF
--- a/.github/policy/rules.rego
+++ b/.github/policy/rules.rego
@@ -33,8 +33,8 @@ deny[msg] {
 
 # Warn if deployments have no prometheus pod annotations
 annotations {
-  input.spec.selector.template.metadata.annotations["prometheus.io/scrape"]
-  input.spec.selector.template.metadata.annotations["prometheus.io/port"]
+  input.spec.template.metadata.annotations["prometheus.io/scrape"]
+  input.spec.template.metadata.annotations["prometheus.io/port"]
 }
 warn[msg] {
   kubernetes.is_deployment


### PR DESCRIPTION
Remove "selector." from "selector.template" with the outcome of:
  input.spec.template.metadata.annotations["prometheus.io/scrape"]
  input.spec.template.metadata.annotations["prometheus.io/port"]
because selector at
https://github.com/fluxcd/multi-tenancy/blob/master/base/flux/deployment.yaml#L7
is a sibling of template at
https://github.com/fluxcd/multi-tenancy/blob/master/base/flux/deployment.yaml#L10